### PR TITLE
[10.x] Fix factory configure return type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -185,7 +185,7 @@ abstract class Factory
     /**
      * Configure the factory.
      *
-     * @return $this
+     * @return static
      */
     public function configure()
     {


### PR DESCRIPTION
**TL;DR**: Small doc block fix

The `Factory::configure()` method currently indicates that it returns `$this` (the exact instance the method was called on), but this is not always true. For example, when calling the `afterCreating()` method a new factory instance is created, e.g.:

```php
    /**
     * @return static
     */
    public function configure(): static
    {
        return $this->afterCreating(static function (MyModel $model) {
            doSomethingWithTheModel($model);
        });
    }
```

For most IDEs this isn't an issue because they will handle `$this` and `static` the same way, but tools like PHPStan do differentiate between them. When using PHPStan strict rules, you would get an error here because the `@return static` in the example doesn't comply with the `@return $this` on the base factory, and if you changed it to `@return $this` it will also fail because you are in fact returning a new instance (the return type for `afterCreating()` is documented as `static`).

This PR solves this by fixing the return type on the configure method, this is not a breaking change as its only a docblock type and `static` encompasses `$this` so anyone using `@return $this` is still fine.